### PR TITLE
Updatecli cleanup

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -23,4 +23,4 @@ jobs:
         uses: updatecli/updatecli-action@92a13b95c2cd9f1c6742c965509203c6a5635ed7 # v2.68.0
 
       - name: Run Updatecli in enforce mode
-        run: "updatecli compose apply --values ./updatecli/values.yaml"
+        run: "updatecli compose apply"

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Run Updatecli in enforce mode
         run: "updatecli compose apply"
+        env:
+          GITHUB_ACTOR: "${{ github.actor }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/updatecli/updatecli.d/updcli-kw-ver.yml
+++ b/updatecli/updatecli.d/updcli-kw-ver.yml
@@ -16,9 +16,8 @@ scms:
   default:
     kind: github
     spec:
-      user: "kubewarden"
-      email: kubewarden@suse.de
-      owner: "kubewarden"
+      #owner: "kubewarden"
+      owner: "olblak"
       repository: kubewarden.io
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
@@ -37,7 +36,8 @@ sources:
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       versionfilter:
         kind: semver
-        pattern: ">0.1"
+        #pattern: ">0.1"
+        pattern: "<1.18.0"
     transformers:
       - trimprefix: "v"
       - findsubmatch:

--- a/updatecli/updatecli.d/updcli-kw-ver.yml
+++ b/updatecli/updatecli.d/updcli-kw-ver.yml
@@ -16,12 +16,12 @@ scms:
   default:
     kind: github
     spec:
-      #owner: "kubewarden"
-      owner: "olblak"
+      owner: "kubewarden"
       repository: kubewarden.io
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: main
+      commitusingapi: true
       commitmessage:
         footers: "Signed-off-by: Kubewarden bot <cncf-kubewarden-maintainers@lists.cncf.io>"
 
@@ -36,8 +36,7 @@ sources:
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       versionfilter:
         kind: semver
-        #pattern: ">0.1"
-        pattern: "<1.18.0"
+        pattern: ">0.1"
     transformers:
       - trimprefix: "v"
       - findsubmatch:

--- a/updatecli/updatecli.d/updcli-kw-ver.yml
+++ b/updatecli/updatecli.d/updcli-kw-ver.yml
@@ -3,7 +3,6 @@ pipelineid: kubewarden-controller/latest
 
 actions:
   default:
-    title: 'updatecli: docs: update Kubewarden version to {{ source "kwc-version" }} on front page of kubewarden.io'
     kind: github/pullrequest
     scmid: default
     spec:
@@ -25,8 +24,6 @@ scms:
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: main
       commitmessage:
-        type: "chore"
-        title: 'docs: update Kubewarden version to {{ source "kwc-version" }} on kubewarden.io front page'
         footers: "Signed-off-by: Kubewarden bot <cncf-kubewarden-maintainers@lists.cncf.io>"
 
 sources:

--- a/updatecli/values.yml
+++ b/updatecli/values.yml
@@ -1,6 +1,0 @@
-github:
-  owner: "UPDATECLI_GITHUB_OWNER"
-  token: "UPDATECLI_GITHUB_TOKEN"
-  author: "Kubewarden bot"
-  email: "cncf-kubewarden-maintainers@lists.cncf.io"
-  user: "UPDATECLI_GITHUB_OWNER"


### PR DESCRIPTION
This pullrequest changes a few things

1. Specify GITHUB_TOKEN within the GitHub action workflow, otherwise Updatecli can't commit changes
2. Remove duplicated commit title configuration, now updatecli uses the Target name by default
3. Set `commitusingapi` to true, so the commit created within the GitHub action is signed by GitHub, cfr https://github.com/olblak/kubewarden.io/pull/3/commits/9084f2212e5d9f672bd598177c1eed432673721c
4. Remove the unused values.yaml